### PR TITLE
ApplicationGroup refactor

### DIFF
--- a/src/drift.core.services.azuredevops.tests/GraphServiceTests.cs
+++ b/src/drift.core.services.azuredevops.tests/GraphServiceTests.cs
@@ -67,12 +67,14 @@ namespace Rangers.Antidrift.Drift.Core.Services.AzureDevOps.Tests
             var url = $"https://dev.azure.com/{this.Organization}";
             var connection = new VssConnection(new Uri(url), credentials);
 
-            var applicationGroup = new ApplicationGroup { Name = "Contributors" };
             var teamProject = new TeamProject { Id = this.Antidrift, Name = "Antidrift" };
 
             var expected = new List<string> { "Antidrift Team" };
 
             var target = new GraphService(connection);
+
+            var applicationGroups = await target.GetApplicationGroups(teamProject).ConfigureAwait(false);
+            var applicationGroup = applicationGroups.Single(ag => ag.Name == "Contributors");
 
             // Act
             var actual = await target.GetMembers(teamProject, applicationGroup).ConfigureAwait(false);

--- a/src/drift.core.tests/model/SecurityPatternTests.cs
+++ b/src/drift.core.tests/model/SecurityPatternTests.cs
@@ -53,7 +53,7 @@ namespace Rangers.Antidrift.Drift.Core.Tests
         {
             // Arrange
             var applicationGroup = new ApplicationGroup { Name = "ApplicationGroup", Members = new[] { "Member 1" } };
-            var current = new List<ApplicationGroup> { new ApplicationGroup { Name = "ApplicationGroup" } };
+            var current = new List<ApplicationGroup> { new ApplicationGroup { Name = "ApplicationGroup", Descriptor = "test123" } };
             var graphService = new Mock<IGraphService>();
             var teamProject = new TeamProject();
 

--- a/src/drift.core.tests/model/SecurityPatternTests.cs
+++ b/src/drift.core.tests/model/SecurityPatternTests.cs
@@ -53,7 +53,7 @@ namespace Rangers.Antidrift.Drift.Core.Tests
         {
             // Arrange
             var applicationGroup = new ApplicationGroup { Name = "ApplicationGroup", Members = new[] { "Member 1" } };
-            var current = new List<ApplicationGroup> { new ApplicationGroup { Name = "ApplicationGroup", Descriptor = "test123" } };
+            var current = new List<ApplicationGroup> { new ApplicationGroup { Name = "ApplicationGroup" } };
             var graphService = new Mock<IGraphService>();
             var teamProject = new TeamProject();
 

--- a/src/drift.core/model/SecurityPattern.cs
+++ b/src/drift.core/model/SecurityPattern.cs
@@ -44,8 +44,13 @@ namespace Rangers.Antidrift.Drift.Core
                 .Select(ag => new ApplicationGroupDeviation { ApplicationGroup = ag, TeamProject = teamProject, Type = DeviationType.Obsolete })
                 .ToList();
 
-            foreach (var applicationGroup in this.ApplicationGroups)
+            var matchingApplicationGroups = this.ApplicationGroups.Where(ag => currentApplicationGroups.Select(cag => cag.Name).Contains(ag.Name, StringComparer.OrdinalIgnoreCase));
+
+            foreach (var applicationGroup in matchingApplicationGroups)
             {
+                // Set the found descriptor
+                applicationGroup.Descriptor = currentApplicationGroups.Single(cag => cag.Name.Equals(applicationGroup.Name, StringComparison.OrdinalIgnoreCase)).Descriptor;
+
                 var currentMembers = currentApplicationGroups.Any(ag => ag.Name.Equals(applicationGroup.Name, StringComparison.OrdinalIgnoreCase))
                                      ? (await this.graphService.GetMembers(teamProject, applicationGroup).ConfigureAwait(false))
                                      : new List<string>();


### PR DESCRIPTION
* prevent 2 needless calls for information that should already be present in the normal flow
* Make sure descriptor is also available for future calls (securityservice will need it as well)